### PR TITLE
fix: client.user_actions needs `actions_filter` instead of `filter`

### DIFF
--- a/dalec_discourse/proxy.py
+++ b/dalec_discourse/proxy.py
@@ -155,7 +155,7 @@ class DiscourseProxy(Proxy):
         # 4 = topic
         # 5 = reply
         topics_and_replies = client.user_actions(
-            username=channel_object, filter="4,5", **self.request_opts
+            username=channel_object, actions_filter="4,5", **self.request_opts
         )
 
         contents = {}

--- a/dalec_discourse/proxy.py
+++ b/dalec_discourse/proxy.py
@@ -167,7 +167,7 @@ class DiscourseProxy(Proxy):
         if LooseVersion(pyd_current_version) < LooseVersion(pyd_required_version):
             user_actions_kwargs["filter"] = filter_value
             warnings.warn(
-                "This minor version is the last to support pydiscourse 1.5.0",
+                "This minor version is the last to support pydiscourse < 1.6.0",
                 DeprecationWarning,
                 stacklevel=2,
             )


### PR DESCRIPTION
In `DiscourseProxy._fetch_user_topics_and_replies` method\
Rename `filter` argument to `actions_filter` to fix:\
`TypeError: user_actions() missing 1 required positional argument: 'actions_filter'`

Because in `DiscourseClient.user_actions` method, we have :
```py
    def user_actions(self, username, actions_filter, offset=0, **kwargs):
        …
        kwargs["filter"] = actions_filter
```